### PR TITLE
Integrating with FeaturePeek

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js: 'lts/carbon'
+branches:
+  except:
+  - gh-pages
+script:
+  - npm run build
+  - bash <(curl -s https://peek.run/ci)

--- a/peek.yaml
+++ b/peek.yaml
@@ -1,0 +1,1 @@
+staticBuildPath: _www


### PR DESCRIPTION
This pull request integrates videojs.com with [FeaturePeek](https://featurepeek.com). 

FeaturePeek lets you preview your front-end builds on every pull request, before you merge in any code. This way you can see what a PR build looks like without checking out the branch locally. You can also submit feedback directly from the running environment, and the feedback gets recorded in the open pull request on GitHub. 

You'll need to configure your CI account to watch the videojs.com repo. It looks like there isn't CI set up yet, so I added a Travis config. Feel free to modify it to your liking. Then you can create a FeaturePeek account – it's free to use for public open source repositories like videojs.com. 

This PR contains a deployment status that points to the running environment. I've set it to public, so anyone with the link can view it.

Take a look at the diff, it's super minimal :-) 